### PR TITLE
Move flipping into format task to prevent release step to fail

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
   "scripts": {
     "deploy": "sam build && sam deploy",
     "deploy-guided": "sam build && sam deploy --guided",
-    "echo-version": "npm run flip && echo v`node -e \"console.log(require('node-yaml').readSync('template-flipped.yaml').Mappings.Solution.Constants.Version)\"`",
+    "echo-version": "echo v`node -e \"console.log(require('node-yaml').readSync('template-flipped.yaml').Mappings.Solution.Constants.Version)\"`",
     "flip": "cfn-flip -c -n -l template.yaml template-flipped.yaml",
-    "format-version": "VERSION=$(npm run echo-version --silent);sed -i '' -e \"3s/.*/Description: Frontend Service Discovery on AWS (uksb-1tthgi8k7) (version:$VERSION)/\" template.yaml",
+    "format-version": "npm run flip;VERSION=$(npm run echo-version --silent);sed -i '' -e \"3s/.*/Description: Frontend Service Discovery on AWS (uksb-1tthgi8k7) (version:$VERSION)/\" template.yaml",
     "test": "jest"
   },
   "type": "module"


### PR DESCRIPTION
*Description of changes:*

In the previous PR we introduced a change in the package.json scripts because of a failed pre-commit tasks. This change should still work for pre-commit but not interfere with the release Github Action, currently failing.

```
Run function version { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $[1](https://github.com/awslabs/frontend-discovery-service/actions/runs/4500237986/jobs/7919103368#step:9:1),$2,$3,$4); }'; }
sh: 1: cfn-flip: not found
sh: 1: cfn-flip: not found
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
