### PR TITLE
cancelled deploys should clear deploymentId

### DIFF
--- a/infrastructure/lambda/adminApi/app.js
+++ b/infrastructure/lambda/adminApi/app.js
@@ -495,7 +495,7 @@ export const deleteDeploymentApi = middy().handler(async (event, context) => {
       projectId: projectId,
       microFrontendId: microFrontendId,
     },
-    UpdateExpression: "set activeVersions = :v, #def = :d",
+    UpdateExpression: "set activeVersions = :v, #def = :d remove deploymentId",
     ExpressionAttributeValues: {
       ":v": initState.state.activeVersions,
       ":d": initState.state.default,

--- a/template.yaml
+++ b/template.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
-Description: Frontend Service Discovery on AWS (uksb-1tthgi8k7) (version:v1.1)
+Description: Frontend Service Discovery on AWS (uksb-1tthgi8k7) (version:v1.2)
 
 Globals:
   Function:
@@ -68,7 +68,7 @@ Conditions:
 Mappings:
   Solution:
     Constants:
-      Version: '1.1'
+      Version: '1.2'
 
 Resources:
   ProjectStore:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

When cancelling a deploy we were not properly clearing the deployment marker on a MFE which prevented subsequent deployments.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
