### PR TITLE
Adds note to API.md to clarify payload on first MFE version

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -237,6 +237,10 @@ Example Response:
 }
 ```
 
+Note: When adding the first MicroFrontend version, the "deploymentStrategy" property must be omitted from the payload.
+
+
+
 ---
 ```POST	/projects/{projectId}/microFrontends/{microFrontendId}/deployment	```
 


### PR DESCRIPTION
Adds note to the /{microFrontendId}/versions POST action, to clarify that "deploymentStrategy" property must be omitted when deploying the first MFE version.

See: [https://github.com/awslabs/frontend-discovery/issues/4](https://github.com/awslabs/frontend-discovery/issues/4)

*Description of changes:*

Added a note to the docs
