### PR TITLE
Admin API: Include current traffic distribution

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -91,7 +91,13 @@ Example Response:
     "microFrontends": [
         {
             "name": "my-project/catalog-123",
-            "id": "27a7928f-9ae2-4f6a-bc51-8478c91f7517"
+            "id": "27a7928f-9ae2-4f6a-bc51-8478c91f7517",
+            "activeVersions": [
+                {
+                    "traffic": 100,
+                    "version": "2.0.0"
+                }
+            ]
         }
     ]
 }
@@ -175,6 +181,12 @@ Example Response:
 {
     "projectId": "ccc1673f-02aa-48cd-b82a-a7911e7150ab",
     "microFrontendId": "27a7928f-9ae2-4f6a-bc51-8478c91f7517",
+    "activeVersions": [
+        {
+            "traffic": 100,
+            "version": "2.0.0"
+        }
+    ],
     "versions": [
         {
             "url": "https://static.example.com/my-account-1.0.0.js",

--- a/infrastructure/lambda/adminApi/app.js
+++ b/infrastructure/lambda/adminApi/app.js
@@ -141,6 +141,7 @@ export const getFrontendsApi = middy().handler(async (event, context) => {
     let resultItem = {
       name: `${project.name}/${mfe.name}`,
       id: mfe.microFrontendId,
+      activeVersions: mfe.activeVersions,
     };
     if (mfe.deleted) resultItem.deleted = mfe.deleted;
     return resultItem;
@@ -175,6 +176,7 @@ export const getFrontendVersionsApi = middy().handler(
 
     result.name = `${project.name}/${mfe.name}`;
     result.versions = versions.map((v) => v.data);
+    result.activeVersions = mfe.activeVersions;
 
     return {
       statusCode: 200,

--- a/template.yaml
+++ b/template.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
-Description: Frontend Service Discovery on AWS (uksb-1tthgi8k7) (version:v1.2)
+Description: Frontend Service Discovery on AWS (uksb-1tthgi8k7) (version:v1.3)
 
 Globals:
   Function:
@@ -68,7 +68,7 @@ Conditions:
 Mappings:
   Solution:
     Constants:
-      Version: '1.2'
+      Version: '1.3'
 
 Resources:
   ProjectStore:

--- a/tests/adminApi.test.js
+++ b/tests/adminApi.test.js
@@ -234,6 +234,7 @@ describe("Admin Api", () => {
         {
           name: `${projectStub.name}/${mfeStub.name}`,
           id: mfeStub.microFrontendId,
+          activeVersions: mfeStub.activeVersions,
         },
       ],
     });
@@ -271,6 +272,7 @@ describe("Admin Api", () => {
         {
           name: `${projectStub.name}/${mfeStub.name}`,
           id: mfeStub.microFrontendId,
+          activeVersions: mfeStub.activeVersions,
           deleted: true,
         },
       ],
@@ -320,6 +322,7 @@ describe("Admin Api", () => {
       projectId: projectStub.projectId,
       name: `${projectStub.name}/${mfeStub.name}`,
       microFrontendId: event.pathParameters.microFrontendId,
+      activeVersions: mfeStub.activeVersions,
       versions: versionsStub.Items.map((v) => v.data),
     });
     expect(result.statusCode).toBe(200);

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -338,6 +338,12 @@ describe("getting a list of frontends for a project", () => {
           {
             name: `${project.name}/${mfe.name}`,
             id: mfe.id,
+            activeVersions: [
+              {
+                version: mfeVersion1.metadata.version,
+                traffic: 100,
+              },
+            ],
           },
         ],
       };
@@ -385,6 +391,12 @@ describe("getting an mfe with versions", () => {
         projectId: project.id,
         microFrontendId: mfe.id,
         name: `${project.name}/${mfe.name}`,
+        activeVersions: [
+          {
+            version: mfeVersion1.metadata.version,
+            traffic: 100,
+          },
+        ],
         versions: [mfeVersion1, mfeVersion2],
       };
       expect(response.body).toStrictEqual(expected);


### PR DESCRIPTION
*Issue #, if available:* 

Closes: #28

*Description of changes:*

Adds the activeVersions for an MFE to the responses to the following endpoints of the Admin API:

`/projects/{projectId}/microFrontends/{microFrontendId}/versions`
`/projects/{projectId}/microFrontends`